### PR TITLE
refactor(github): changes setup for GitHub auth token

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,8 +1,19 @@
 import fetchMock from "fetch-mock";
 import { GitHub, IResponse, ISearchResponse } from "./github";
 
+function createGitHub() {
+  const authToken = process.env.GITHUB_AUTH_TOKEN;
+  if (!authToken) {
+    throw new Error(
+      "Must set `GITHUB_AUTH_TOKEN` environmental variable for tests to run."
+    );
+  }
+
+  return new GitHub({ authToken });
+}
 test("fetching from a busy, public organization", async () => {
-  const response = await GitHub.recentlyClosedPullRequests({
+  const github = createGitHub();
+  const response = await github.recentlyClosedPullRequests({
     endDate: new Date("5/7/19"),
     organization: "microsoft",
     startDate: new Date("5/1/19")
@@ -41,7 +52,8 @@ test("responses are formatted to be groups by repo, and 'cleaned up'", async () 
       return { data: mockResponse };
     });
 
-  const resp = await GitHub.recentlyClosedPullRequests({
+  const github = createGitHub();
+  const resp = await github.recentlyClosedPullRequests({
     endDate: new Date(),
     organization: "my-org",
     request: { fetch },
@@ -74,7 +86,8 @@ test("search string include the specified org and date range", async () => {
       }
     );
 
-  const resp = await GitHub.recentlyClosedPullRequests({
+  const github = createGitHub();
+  const resp = await github.recentlyClosedPullRequests({
     endDate: new Date("1/7/2019"),
     organization: "my-org",
     request: { fetch },

--- a/src/github.ts
+++ b/src/github.ts
@@ -73,12 +73,18 @@ interface IGitHubGraphqlArgs {
 }
 
 export class GitHub {
-  public static async recentlyClosedPullRequests(
+  token: string;
+
+  constructor({ authToken }: { authToken: string }) {
+    this.token = authToken;
+  }
+
+  public async recentlyClosedPullRequests(
     params: IRequestParams
   ): Promise<IPullRequestsForRepos> {
     let requestArgs: IGitHubGraphqlArgs = {
       headers: {
-        authorization: `token ${process.env.GITHUB_AUTH_TOKEN}`
+        authorization: `token ${this.token}`
       },
       query: closedPullRequestsQuery,
       searchString: this.__searchQueryString(params)
@@ -112,7 +118,7 @@ export class GitHub {
     }, pullRequestsGroupsByRepo);
   }
 
-  public static __searchQueryString({
+  public __searchQueryString({
     organization,
     startDate,
     endDate

--- a/src/github.ts
+++ b/src/github.ts
@@ -73,7 +73,7 @@ interface IGitHubGraphqlArgs {
 }
 
 export class GitHub {
-  token: string;
+  private token: string;
 
   constructor({ authToken }: { authToken: string }) {
     this.token = authToken;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,21 +4,24 @@ import { fetchRecentlyClosedPullRequests } from "./index";
 // Reset Date back to the real date
 afterEach(() => MockDate.reset());
 
-class FakeService {
-  public static async recentlyClosedPullRequests(): Promise<any> {
-    return {};
-  }
-  public static __searchQueryString(): string {
-    return "";
-  }
-}
-
-const fakeApiCall = (FakeService.recentlyClosedPullRequests = jest.fn());
-
 test("dates default to the last week", () => {
   MockDate.set("1/8/2019");
 
-  fetchRecentlyClosedPullRequests({ organization: "my-org" }, FakeService);
+  jest.mock("./github");
+  const MockedGitHub = require("./github").GitHub;
+
+  const fakeApiCall = jest.fn().mockImplementation();
+  MockedGitHub.mockImplementation(() => {
+    return {
+      recentlyClosedPullRequests: fakeApiCall
+    };
+  });
+
+  fetchRecentlyClosedPullRequests(
+    { organization: "my-org" },
+    "fake-token",
+    MockedGitHub
+  );
 
   expect(fakeApiCall).toHaveBeenCalledWith({
     endDate: new Date("1/7/2019"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ interface IRequestParams {
 
 export function fetchRecentlyClosedPullRequests(
   requestParams: IRequestParams,
-  service = GitHub
+  authToken: string,
+  Service = GitHub
 ) {
   const dates = {
     endDate: subDays(new Date(), 1),
@@ -21,5 +22,5 @@ export function fetchRecentlyClosedPullRequests(
     } that were closed between ${dates.startDate} and ${dates.endDate}`
   );
 
-  return service.recentlyClosedPullRequests(args);
+  return new Service({ authToken }).recentlyClosedPullRequests(args);
 }


### PR DESCRIPTION
Previously, we expected a `GITHUB_AUTH_TOKEN` environment variable to be
set. To make things more flexible, this commit changes to require you to
make an instance of a `GitHub` class, and pass in the auth token. This
allows the end user to get the token however they want and no longer
ties them to specific environment variables.

BREAKING CHANGE: Previously, you had to have a `GITHUB_AUTH_TOKEN`
environment variable that would be used in `GitHub` class methods. The
API has changed to instead create in instance of `GitHub` by passing in
your auth token however works for you in your code. Previously used
class method `recentlyClosedPullRequests` is now an instance method on
`GitHub`.