### PR TITLE
ci(dependabot): creates and customized dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
Creates config for dependabot, and uses `prefix` and
`prefix_development` options to make commit messages align with what
comitizen and semantic-version expect. [This
issue](https://github.com/semantic-release/semantic-release/issues/1329)
is what pointed me in the right direction.